### PR TITLE
remove dataclasses from install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords=['verilog', 'VHDL', 'vcd', 'fst', 'development', 'hardware', 'rtl', 'simulation', 'verification', 'FPGA'],
     packages=find_packages(),
     python_requires='>=3.8, <4',
-    install_requires=['lark-parser', 'dataclasses', 'pylibfst','importlib-resources'],
+    install_requires=['lark-parser', 'pylibfst'],
     extras_require={
         'dev': [],
         'test': ['ruff', 'coverage'],


### PR DESCRIPTION
dataclasses is built-in into python 3.7.
Since python_requires is specified with '>=3.8', we can assume that the dataclass module is exists.
If we don't remove this dependency, setuptools will try to find 'dataclasses' from distribution cache, not from built-in, and thus cause install error.