### PR TITLE
Bugfix vcd files

### DIFF
--- a/wal/trace/vcd.py
+++ b/wal/trace/vcd.py
@@ -140,6 +140,9 @@ class TraceVcd(Trace):
         data_by_name = {signal: self.data[self.name2id[signal]] for signal in self.rawsignals}
         self.data = data_by_name
 
+        # Remember all timestamps
+        self.all_timestamps = self.timestamps
+
     def access_signal_data(self, name, index):
         return self.data[name][index]
     

--- a/wal/trace/vcd.py
+++ b/wal/trace/vcd.py
@@ -46,6 +46,11 @@ class TraceVcd(Trace):
                 width = tokens[i + 2]
                 id = tokens[i + 3]
                 name = tokens[i + 4]
+
+                # Remove bit width annotations from the name
+                if name.endswith(']'):
+                    name= name.split('[')[0]
+
                 # only append scope. if not in root scope
                 if scope:
                     fullname = '.'.join(scope) + '.' + name


### PR DESCRIPTION
This merge fixes two bugs for VCD files:

- For `FST` files, the property `all_timestamps` was set which is needed to sample the timestamps. For `VCD` files, the property `all_timestamps` was **not** set.
- Some `VCD` files do not have a space between variable names and bitwidth annotations. The parser has been made less strict in order to allow bitwidth annotations directly next to the name.