### PR TITLE
Fix KeyError in VCD trace parsing for undefined signal IDs

### DIFF
--- a/wal/trace/vcd.py
+++ b/wal/trace/vcd.py
@@ -39,7 +39,7 @@ class TraceVcd(Trace):
         self.signals = set(Trace.SPECIAL_SIGNALS + self.rawsignals)
 
         self.id2name = {v: k for k, v in self.name2id.items()}
-        self.rawsignals_by_handle = [self.id2name[s] for s in self.all_ids]
+        self.rawsignals_by_handle = [self.id2name[s] for s in self.all_ids if s in self.id2name]
         self.signals_by_handle = set(self.rawsignals_by_handle)
 
     def parse(self, vcddata):


### PR DESCRIPTION
Filter out signal IDs that are not present in the id2name mapping building rawsignals_by_handle. 
This prevents crashes when VCD files containing signal references without definitions.
